### PR TITLE
Fixes caching in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,14 @@ executors:
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/postgres:9.4
 
-    #### TEMPLATE_NOTE: go expects specific checkout path representing url
-    #### expecting it in the form of
-    ####   /go/src/github.com/circleci/go-tool
-    ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    working_directory: /home/circleci/project
+    environment:
+      GOPATH: /home/circleci/go
 
 commands:
   setup:
     steps:
+    - run: mkdir /home/circleci/project && cd /home/circleci/project
     - checkout
     - setup_remote_docker
     - restore_cache:
@@ -56,7 +55,7 @@ jobs:
       - save_cache:
           key: go-cache-{{ arch }}-{{ checksum "go.sum" }}
           paths:
-          - /go
+          - /home/circleci/go
   push_master_image:
     executor: default
     steps:
@@ -70,7 +69,7 @@ jobs:
       - save_cache:
           key: go-cache-{{ arch }}-{{ checksum "go.sum" }}
           paths:
-          - /go
+          - /home/circleci/go
   push_release_image:
     executor: default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
 commands:
   setup:
     steps:
-    - run: mkdir /home/circleci/project && cd /home/circleci/project
+    - run: mkdir -p /home/circleci/project && cd /home/circleci/project
     - checkout
     - setup_remote_docker
     - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
     - setup_remote_docker
     - restore_cache:
         keys:
-        - go-cache-{{ arch }}-{{ checksum "go.sum" }}
+        - go-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
   docker_login:
     steps:
     - run: docker login --username="$DOCKER_USER" --password="$DOCKER_PASSWORD"
@@ -53,7 +53,7 @@ jobs:
       - build_image:
           tag: $CIRCLE_SHA1
       - save_cache:
-          key: go-cache-{{ arch }}-{{ checksum "go.sum" }}
+          key: go-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
           paths:
           - /home/circleci/go
   push_master_image:
@@ -67,7 +67,7 @@ jobs:
       - push_image:
           tag: master-$CIRCLE_SHA1
       - save_cache:
-          key: go-cache-{{ arch }}-{{ checksum "go.sum" }}
+          key: go-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
           paths:
           - /home/circleci/go
   push_release_image:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+node-relabeler
 
 # IDEs and editors
 .vscode/


### PR DESCRIPTION
`/go` is inaccessible for writing by the guild user, which is breaking cache restore step. So we need to use a directory under the user home.