### PR TITLE
Reduces flakiness of controller tests.

### DIFF
--- a/pkg/cmd/relabel.go
+++ b/pkg/cmd/relabel.go
@@ -79,5 +79,5 @@ func startRelabeler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return controller.Run(stop)
+	return controller.Run(stop, stop)
 }

--- a/pkg/kube/controller.go
+++ b/pkg/kube/controller.go
@@ -44,6 +44,10 @@ func NewController(client kubernetes.Interface, specs specs.Specs) (*Controller,
 
 // Run runs the controller until the stop channel is signalled.
 func (c *Controller) Run(stopCh <-chan struct{}, stopSyncCh <-chan struct{}) error {
+	return c.runInternal(stopCh, stopCh)
+}
+
+func (c *Controller) runInternal(stopCh <-chan struct{}, stopSyncCh <-chan struct{}) error {
 	c.informerFactory.Start(stopCh)
 	if !cache.WaitForCacheSync(stopSyncCh, c.nodeInformer.Informer().HasSynced) {
 		return fmt.Errorf("Failed to sync node informer cache")

--- a/pkg/kube/controller.go
+++ b/pkg/kube/controller.go
@@ -43,9 +43,9 @@ func NewController(client kubernetes.Interface, specs specs.Specs) (*Controller,
 }
 
 // Run runs the controller until the stop channel is signalled.
-func (c *Controller) Run(stopCh <-chan struct{}) error {
+func (c *Controller) Run(stopCh <-chan struct{}, stopSyncCh <-chan struct{}) error {
 	c.informerFactory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, c.nodeInformer.Informer().HasSynced) {
+	if !cache.WaitForCacheSync(stopSyncCh, c.nodeInformer.Informer().HasSynced) {
 		return fmt.Errorf("Failed to sync node informer cache")
 	}
 	<-stopCh

--- a/pkg/kube/controller_test.go
+++ b/pkg/kube/controller_test.go
@@ -102,7 +102,7 @@ func TestControllerLabelUpdate(t *testing.T) {
 			case <-updateChan:
 				// cache.WaitForCacheSync has the sync period of 100ms.
 				// We have to outwait that to make sure it syncs.
-				time.Sleep(110 * time.Millisecond)
+				time.Sleep(125 * time.Millisecond)
 				close(stopChan)
 				<-doneChan
 				updated, err := fakeClient.CoreV1().Nodes().Get(

--- a/pkg/kube/controller_test.go
+++ b/pkg/kube/controller_test.go
@@ -80,7 +80,7 @@ func TestControllerLabelUpdate(t *testing.T) {
 				Labels: map[string]string{"abc": "def"},
 			}}
 			fakeClient := fake.NewSimpleClientset(node)
-			updateChan := make(chan struct{}, 1)
+			updateChan := make(chan struct{})
 			fakeClient.PrependReactor(
 				"update",
 				"nodes",
@@ -102,7 +102,7 @@ func TestControllerLabelUpdate(t *testing.T) {
 			case <-updateChan:
 				// cache.WaitForCacheSync has the sync period of 100ms.
 				// We have to outwait that to make sure it syncs.
-				time.Sleep(125 * time.Millisecond)
+				time.Sleep(225 * time.Millisecond)
 				close(stopChan)
 				<-doneChan
 				updated, err := fakeClient.CoreV1().Nodes().Get(

--- a/pkg/kube/controller_test.go
+++ b/pkg/kube/controller_test.go
@@ -92,10 +92,11 @@ func TestControllerLabelUpdate(t *testing.T) {
 			controller, err := NewController(fakeClient, specs)
 			require.NoError(t, err)
 			stopChan := make(chan struct{})
-			stopSyncChan := make(chan struct{})
+			stopCacheSyncChan := make(chan struct{})
 			doneChan := make(chan struct{})
 			go func(stop <-chan struct{}, done chan<- struct{}) {
-				err = controller.Run(stopChan, stopSyncChan)
+				// We use runInternal here to avoid interupting the cache sync.
+				err = controller.runInternal(stopChan, stopCacheSyncChan)
 				assert.NoError(t, err)
 				close(done)
 			}(stopChan, doneChan)

--- a/pkg/kube/controller_test.go
+++ b/pkg/kube/controller_test.go
@@ -80,7 +80,7 @@ func TestControllerLabelUpdate(t *testing.T) {
 				Labels: map[string]string{"abc": "def"},
 			}}
 			fakeClient := fake.NewSimpleClientset(node)
-			updateChan := make(chan struct{})
+			updateChan := make(chan struct{}, 1)
 			fakeClient.PrependReactor(
 				"update",
 				"nodes",

--- a/pkg/kube/controller_test.go
+++ b/pkg/kube/controller_test.go
@@ -92,17 +92,15 @@ func TestControllerLabelUpdate(t *testing.T) {
 			controller, err := NewController(fakeClient, specs)
 			require.NoError(t, err)
 			stopChan := make(chan struct{})
+			stopSyncChan := make(chan struct{})
 			doneChan := make(chan struct{})
 			go func(stop <-chan struct{}, done chan<- struct{}) {
-				err = controller.Run(stopChan)
+				err = controller.Run(stopChan, stopSyncChan)
 				assert.NoError(t, err)
 				close(done)
 			}(stopChan, doneChan)
 			select {
 			case <-updateChan:
-				// cache.WaitForCacheSync has the sync period of 100ms.
-				// We have to outwait that to make sure it syncs.
-				time.Sleep(225 * time.Millisecond)
 				close(stopChan)
 				<-doneChan
 				updated, err := fakeClient.CoreV1().Nodes().Get(


### PR DESCRIPTION
This give more time for the cache to sync before shutting down.