### PR TITLE
Blocks auto-recursive specs.

### DIFF
--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -10,10 +10,13 @@ import (
 
 // Spec contains a parsed relabel spec, ready to apply to node labels.
 type spec struct {
-	OldKey   *regexp.Regexp
-	OldValue *regexp.Regexp
-	NewKey   string
-	NewValue string
+	oldKeyRegexp   *regexp.Regexp
+	oldValueRegexp *regexp.Regexp
+	oldKey         string
+	oldValue       string
+	newKey         string
+	newValue       string
+	stringSpec     string
 }
 
 // Specs keeps compiled relabeling specs and applies them.
@@ -58,18 +61,39 @@ func Parse(specs []string) (Specs, error) {
 				"Wildcard pattern cannot appear in new label without appearing in the old one")
 		}
 
-		parsedSpecs = append(parsedSpecs, spec{
-			OldKey: regexp.MustCompile(fmt.Sprintf(
+		newSpec := spec{
+			oldKeyRegexp: regexp.MustCompile(fmt.Sprintf(
 				"^%s$",
 				strings.Replace(oldKey, "*", "(.*)", 1),
 			)),
-			OldValue: regexp.MustCompile(fmt.Sprintf(
+			oldValueRegexp: regexp.MustCompile(fmt.Sprintf(
 				"^%s$",
 				strings.Replace(oldValue, "*", "(.*)", 1),
 			)),
-			NewKey:   newKey,
-			NewValue: newValue,
-		})
+			oldKey:     oldKey,
+			oldValue:   oldValue,
+			newKey:     newKey,
+			newValue:   newValue,
+			stringSpec: stringSpec,
+		}
+		if strings.Contains(newSpec.oldKey, "*") &&
+			strings.Contains(newSpec.newKey, "*") &&
+			newSpec.oldKey != newSpec.newKey &&
+			newSpec.oldKeyRegexp.MatchString(newSpec.newKey) {
+			return nil, newSpecParseError(
+				stringSpec,
+				"newkey=newvalue pair must not match pattern in oldkey=oldvalue")
+		}
+		if strings.Contains(newSpec.oldValue, "*") &&
+			strings.Contains(newSpec.newValue, "*") &&
+			newSpec.oldValue != newSpec.newValue &&
+			newSpec.oldKeyRegexp.MatchString(newSpec.newKey) &&
+			newSpec.oldValueRegexp.MatchString(newSpec.newValue) {
+			return nil, newSpecParseError(
+				stringSpec,
+				"newkey=newvalue pair must not match pattern in oldkey=oldvalue")
+		}
+		parsedSpecs = append(parsedSpecs, newSpec)
 	}
 	logrus.WithField("specs", parsedSpecs).Debug("Parsed specs from command line")
 	return parsedSpecs, nil
@@ -82,25 +106,25 @@ func (s Specs) ApplyTo(labels map[string]string) map[string]string {
 
 	for key, value := range labels {
 		for _, spec := range s {
-			keyMatch := spec.OldKey.FindStringSubmatch(key)
+			keyMatch := spec.oldKeyRegexp.FindStringSubmatch(key)
 			if keyMatch == nil {
 				continue
 			}
-			valueMatch := spec.OldValue.FindStringSubmatch(value)
+			valueMatch := spec.oldValueRegexp.FindStringSubmatch(value)
 			if valueMatch == nil {
 				continue
 			}
 			var newKey, newValue string
-			if spec.OldKey.NumSubexp() > 0 {
-				newKey = strings.Replace(spec.NewKey, "*", keyMatch[1], 1)
-				newValue = strings.Replace(spec.NewValue, "*", keyMatch[1], 1)
-			} else if spec.OldValue.NumSubexp() > 0 {
-				newKey = strings.Replace(spec.NewKey, "*", valueMatch[1], 1)
-				newValue = strings.Replace(spec.NewValue, "*", valueMatch[1], 1)
+			if spec.oldKeyRegexp.NumSubexp() > 0 {
+				newKey = strings.Replace(spec.newKey, "*", keyMatch[1], 1)
+				newValue = strings.Replace(spec.newValue, "*", keyMatch[1], 1)
+			} else if spec.oldValueRegexp.NumSubexp() > 0 {
+				newKey = strings.Replace(spec.newKey, "*", valueMatch[1], 1)
+				newValue = strings.Replace(spec.newValue, "*", valueMatch[1], 1)
 
 			} else {
-				newKey = spec.NewKey
-				newValue = spec.NewValue
+				newKey = spec.newKey
+				newValue = spec.newValue
 			}
 			replacements[newKey] = newValue
 		}

--- a/pkg/specs/specs_test.go
+++ b/pkg/specs/specs_test.go
@@ -11,78 +11,78 @@ func TestParseSimple(t *testing.T) {
 	specs, err := Parse([]string{"abc=def:uvw=xyz"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc$", specs[0].OldKey.String())
-	assert.Equal(t, "^def$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw", specs[0].NewKey)
-	assert.Equal(t, "xyz", specs[0].NewValue)
+	assert.Equal(t, "^abc$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw", specs[0].newKey)
+	assert.Equal(t, "xyz", specs[0].newValue)
 }
 
 func TestParseKeyWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc*=def:uvw*=xyz"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc(.*)$", specs[0].OldKey.String())
-	assert.Equal(t, "^def$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw*", specs[0].NewKey)
-	assert.Equal(t, "xyz", specs[0].NewValue)
+	assert.Equal(t, "^abc(.*)$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw*", specs[0].newKey)
+	assert.Equal(t, "xyz", specs[0].newValue)
 }
 
 func TestParseValueWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc=def*:uvw=xyz*"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc$", specs[0].OldKey.String())
-	assert.Equal(t, "^def(.*)$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw", specs[0].NewKey)
-	assert.Equal(t, "xyz*", specs[0].NewValue)
+	assert.Equal(t, "^abc$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def(.*)$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw", specs[0].newKey)
+	assert.Equal(t, "xyz*", specs[0].newValue)
 }
 
 func TestParseOldKeyNewValueWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc*=def:uvw=xyz*"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc(.*)$", specs[0].OldKey.String())
-	assert.Equal(t, "^def$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw", specs[0].NewKey)
-	assert.Equal(t, "xyz*", specs[0].NewValue)
+	assert.Equal(t, "^abc(.*)$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw", specs[0].newKey)
+	assert.Equal(t, "xyz*", specs[0].newValue)
 }
 
 func TestParseOldValueNewKeyWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc=def*:uvw*=xyz"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc$", specs[0].OldKey.String())
-	assert.Equal(t, "^def(.*)$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw*", specs[0].NewKey)
-	assert.Equal(t, "xyz", specs[0].NewValue)
+	assert.Equal(t, "^abc$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def(.*)$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw*", specs[0].newKey)
+	assert.Equal(t, "xyz", specs[0].newValue)
 }
 
 func TestParseOldValueNewKeyValueWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc=def*:uvw*=xyz*"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc$", specs[0].OldKey.String())
-	assert.Equal(t, "^def(.*)$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw*", specs[0].NewKey)
-	assert.Equal(t, "xyz*", specs[0].NewValue)
+	assert.Equal(t, "^abc$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def(.*)$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw*", specs[0].newKey)
+	assert.Equal(t, "xyz*", specs[0].newValue)
 }
 func TestParseOldKeyOnlyWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc*=def:uvw=xyz"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc(.*)$", specs[0].OldKey.String())
-	assert.Equal(t, "^def$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw", specs[0].NewKey)
-	assert.Equal(t, "xyz", specs[0].NewValue)
+	assert.Equal(t, "^abc(.*)$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw", specs[0].newKey)
+	assert.Equal(t, "xyz", specs[0].newValue)
 }
 func TestParseOldValueOnlyWildcard(t *testing.T) {
 	specs, err := Parse([]string{"abc=def*:uvw=xyz"})
 	require.NoError(t, err)
 	require.Len(t, specs, 1)
-	assert.Equal(t, "^abc$", specs[0].OldKey.String())
-	assert.Equal(t, "^def(.*)$", specs[0].OldValue.String())
-	assert.Equal(t, "uvw", specs[0].NewKey)
-	assert.Equal(t, "xyz", specs[0].NewValue)
+	assert.Equal(t, "^abc$", specs[0].oldKeyRegexp.String())
+	assert.Equal(t, "^def(.*)$", specs[0].oldValueRegexp.String())
+	assert.Equal(t, "uvw", specs[0].newKey)
+	assert.Equal(t, "xyz", specs[0].newValue)
 }
 
 func TestParseLabelSpecFailures(t *testing.T) {
@@ -130,6 +130,16 @@ func TestParseLabelSpecFailures(t *testing.T) {
 			"BothOldKeyAndValueWildcard",
 			[]string{"abc*=def*:uvw=xyz"},
 			"oldkey=oldvalue pair should contain no more than a single",
+		},
+		{
+			"AutoRecursiveKeyWildcard",
+			[]string{"abc*=123:abcd*=123"},
+			"newkey=newvalue pair must not match pattern in oldkey=oldvalue",
+		},
+		{
+			"AutoRecursiveValueWildcard",
+			[]string{"abc=*:abc=*x"},
+			"newkey=newvalue pair must not match pattern in oldkey=oldvalue",
 		},
 	}
 	for _, testItem := range testData {


### PR DESCRIPTION
Some combinations of specs and labels can cause the relabeler to keep changing labels indefinitely. For example, specification `abc=*:abc=*x` will keep adding `x`s to the value of the label `abc` indefinitely. This can quickly exhaust the cluster API server storage and CPU resources. This change adds a check for subclass of such dangerous specifications.